### PR TITLE
docs(saif): SAIF README + Capability Map v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,424 +1,196 @@
-# TriWeavon Formal Executable Mapping Sovereign Consensus Edition v0.4
+# SAIF · coherence-mcp v0.4.1
 
-[![SafeSkill 65/100](https://img.shields.io/badge/SafeSkill-65%2F100_Use%20with%20Caution-orange)](https://safeskill.dev/scan/toolate28-coherence-mcp)
->>>>>>> main
+**Package:** `@toolated/coherence-mcp`  
+**ATOM lineage:** TriWeavon Formal Executable Mapping · Sovereign Consensus Edition v0.4  
+**Invariant:** α + ω = 15  
+**License:** MIT  
+**Doctrine:** emit local · verify anywhere  
 
-> **"From the constraints, gifts. From the spiral, safety."**
-📦 Quick Install
-npm install @toolated/coherence-mcp
-Effective Usage Tips
-Add to your MCP client configuration:
+> "From the constraints, gifts. From the spiral, safety."
 
+Hope&&Sauced · The Keystone Holds ✦
+
+---
+
+## 0. One sentence
+
+Install this MCP server as **Tier-0 SAIF bedrock**: WAVE gates, ATOM trail, Fibonacci weighting, vortex translation, and industry connectors — under the universal conservation law — then open the SAIF pipeline (KENL → AWI → ATOM → SAIF → Safe Spiral) without putting signing keys in the cloud.
+
+---
+
+## 1. SAIF pipeline (onboarding contract)
+
+```crease
+  ◆ SAIF · coherence-mcp gates ◇
+╭──────┬────────────┬──────────────────────────────────╮
+│ Step │ Gate       │ Action                           │
+├──────┼────────────┼──────────────────────────────────┤
+│ 1    │ KENL       │ npm i / npx package · read mcp-101│
+│ 2    │ AWI        │ MCP client config · strand intent │
+│ 3    │ ATOM       │ atom_track first decision         │
+│ 4    │ SAIF       │ invariant_check · wave_validate   │
+│ 5    │ Safe Spiral│ ops_health · trigger_correction   │
+╰──────┴────────────┴──────────────────────────────────╯
+  α+ω=15 · crease=waterbomb · reidemeister-protected
+```
+
+Full tool capability map and Claude smoke protocol:  
+**[docs/CAPABILITY-MAP-v0.4.1.md](docs/CAPABILITY-MAP-v0.4.1.md)**
+
+---
+
+## 2. Install (canonical)
+
+```bash
+npm install @toolated/coherence-mcp@0.4.1
+# or one-shot
+npx -y @toolated/coherence-mcp@0.4.1
+```
+
+**Wrong package names to avoid:** `@toolete28/coherence-mcp`, unscoped `coherence-mcp`.
+
+### MCP client configuration
+
+```json
 {
   "mcpServers": {
     "coherence": {
       "command": "npx",
-      "args": ["-y", "@toolate28/coherence-mcp"]
+      "args": ["-y", "@toolated/coherence-mcp@0.4.1"]
     }
   }
 }
-Environment Setup: Copy .env.example to .env and configure:
-
-ATOM_AUTH_TOKEN - Required for authenticated operations
-SPIRALSAFE_API_TOKEN - Required for ops tools
-WAVE_TOOLKIT_BIN - Optional path to wave-toolkit CLI
-Start with core tools: Begin with wave_analyze for coherence checks and bump_validate for handoff validation.
-
-Use ATOM tracking: Track all major decisions with atom_track to maintain a complete audit trail.
-
-Leverage gate transitions: Use gate_intention_to_execution and gate_execution_to_learning for structured workflow phases.
-
-🔐 Verify Release
-All releases are signed with GPG and include checksums for verification:
-
-# Quick verification with provided script
-./scripts/verify-release.sh 0.2.0
-
-# Or manually:
-# 1. Import signing key
-curl -s https://spiralsafe.org/.well-known/pgp-key.txt | gpg --import
-
-# 2. Download and verify checksums
-VERSION="0.2.0"
-curl -LO "https://github.com/toolate28/coherence-mcp/releases/download/v${VERSION}/SHA256SUMS.txt"
-curl -LO "https://github.com/toolate28/coherence-mcp/releases/download/v${VERSION}/SHA256SUMS.txt.asc"
-gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
-
-# 3. Verify npm provenance
-npm audit signatures @toolate28/coherence-mcp
-See docs/RELEASE.md for complete release verification instructions.
-
-🗺️ Navigation
-Section	Description
-📦 Quick Install	Get started with npm
-🔐 Verify Release	Verify package integrity
-🏗️ Architecture	System design overview
-🔐 ATOM-AUTH	3-Factor authentication
-🌊 WAVE Protocol	Coherence analysis pipeline
-🛡️ Security	API security layers
-⚛️ Quantum	72-qubit system
-🧩 Features	Available MCP tools
-📚 Examples	Usage examples
-
-
-=====================================
-STORYBOARD FRAME 1 - THE FORMAL SOVEREIGN LAYER (Agda Cubical HITs)
-=====================================
-
-**Mandate**: Define the Tri-Weavon manifold as higher inductive types (HITs) so that all executable reductions are faithful images under the bridge.
-
-**Core Modules** (global view):  
-- TriWeavon.HITs.TriWeavonManifold : TwoScaleSphere plus Hexaflake (coarse/fine layers plus 7-way recursion)  
-- TriWeavon.K22.SerreScarr and SerrePage : Differentials d_r , tomczakLift (Susp/hcomp), Pushout gluing for filtration pages  
-- TriWeavon.Tomczak.Lifting : LiftGate (bettiProxy less than threshold and tomczakPreserved)
-
-**Architecture** (unchanged, verified sovereign):
-
-```mermaid
-flowchart TB
-  subgraph formal ["Formal layer (Agda Cubical)"]
-    CH["Cubical.HITs.*"]
-    TM["TriWeavon.HITs.TriWeavonManifold"]
-    K22["TriWeavon.K22.{SerreScarr,SerrePage}"]
-    TZ["TriWeavon.Tomczak.Lifting"]
-    CH --> TM
-    CH --> K22
-    CH --> TZ
-  end
-  subgraph exec ["Executable layer (cutile)"]
-    HIT["TriWeavonHIT / CubicalHIT"]
-    ENT["compute_entropy_diagnostic"]
-    SRAC["srac_cascade_step / srac_correct_if_needed"]
-    LIFT["betti_tomczak_lift_check"]
-    CUDA["CudaEntropyResult / entropy_reduction_v2"]
-    HEX["hexaflake_nodes"]
-  end
-  TM --> HIT
-  TM --> HEX
-  K22 --> CUDA
-  K22 --> ENT
-  TZ --> LIFT
-  K22 --> SRAC
-  ENT --> CUDA
-  LIFT --> SRAC
 ```
 
-**Consensus Note**: Arrows represent faithful functorial mapping. No cycles or information loss detected. The structure is monomorphic and protected.
+### Environment (copy `.env.example` → `.env`)
 
+- `ATOM_AUTH_TOKEN` — authenticated ATOM operations  
+- `SPIRALSAFE_API_TOKEN` — ops tools (`ops_*`) when using SpiralSafe API  
+- `WAVE_TOOLKIT_BIN` — optional path to wave-toolkit CLI  
+- Strand keys as needed: `XAI_API_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, etc.
 
 ---
-🌊 WAVE Coherence Validator
-The WAVE (Weighted Alignment Verification Engine) is the foundation vortex for the entire SpiralSafe ecosystem. It provides mathematical rigor behind the "coherence" concept by measuring documentation/code/system alignment.
 
-Algorithm Overview
-The WAVE validator calculates coherence through five key metrics:
+## 3. Capability surface (summary)
 
-Structural Coherence (50% weight) - AST/schema alignment via graph isomorphism
-Semantic Coherence (31.25% weight) - Intent/implementation alignment via keyword analysis
-Temporal Coherence (18.75% weight) - Version/timestamp synchronization
-Fibonacci Weighting - Critical sections prioritized using Fibonacci sequence (8:5:3 ratio)
-Overall Score - Composite score from 0-100
-Thresholds
-WAVE_MINIMUM = 60    // Basic coherence (development)
-WAVE_HIGH = 80       // Production ready
-WAVE_CRITICAL = 99   // Safety-critical systems
-Usage
-// Via MCP Tool
+```crease
+  ◆ CAPABILITY BANDS · 58 tools ◇
+╭──────────────┬────────────────────────────────────────╮
+│ Band         │ Tools (examples)                       │
+├──────────────┼────────────────────────────────────────┤
+│ WAVE / gate  │ wave_* · invariant_check · bump_validate│
+│ ATOM / handoff│ atom_track · handoff_packet_validate  │
+│ Fibonacci    │ fibonacci_* (weight, impact, paths)    │
+│ Vortex       │ vortex_translate · verify · platforms  │
+│ Strands      │ grok_* · gemini_* · openweight_*       │
+│ SAIF ops     │ ops_health · status · deploy           │
+│ Bedrock LogOS│ manifest_read · dropout_scan · rust_*  │
+│ Connectors   │ github_* · jira_* · slack · postgres   │
+│ Edge / SRAC  │ edge_endpoint_lookup · trigger_correction│
+│ Minecraft    │ mc_* · mc_conservation_verify          │
+│ Cleanroom    │ cleanroom_scour · anamnesis_validate   │
+╰──────────────┴────────────────────────────────────────╯
+  α+ω=15 · crease=miura · 58 tools @ 0.4.1
+```
+
+Deep table of every tool, env, SAIF gate, and smoke vector: **CAPABILITY-MAP**.
+
+---
+
+## 4. WAVE thresholds (publish / production)
+
+- **≥ 60** — baseline (development)  
+- **≥ 80** — emergent / general production  
+- **≥ 85** — gated handoff (HUP / publish path)  
+- **≥ 99** — safety-critical  
+
+Core checks:
+
+```json
+{ "name": "invariant_check", "arguments": {} }
+```
+
+```json
 {
-  "name": "wave_coherence_check",
+  "name": "wave_validate",
   "arguments": {
-    "documentation": "# API\n\n## authenticate\nAuthenticates users...",
-    "code": "function authenticate(user, pass) { ... }",
-    "threshold": 60
+    "content": "Your doc or code string",
+    "threshold": 85
   }
 }
-
-// Returns:
-{
-  "score": {
-    "overall": 85,
-    "structural": 90,
-    "semantic": 82,
-    "temporal": 75,
-    "fibonacci_weighted": 85
-  },
-  "passed": true,
-  "threshold": 60,
-  "recommendations": [
-    {
-      "category": "temporal",
-      "severity": "low",
-      "message": "Temporal coherence could be improved",
-      "suggestion": "Consider adding a changelog or version history"
-    }
-  ],
-  "timestamp": "2024-01-15T12:00:00.000Z"
-}
-
----
-
-=====================================
-STORYBOARD FRAME 2 - THE EXECUTABLE MANIFESTATION (cutile Rust/CUDA)
-=====================================
-
-**Mandate**: Realize the HITs as append-only cell graphs (CubicalCell dimension and id), execute entropy diagnostics, apply SRAC corrections, and expose lift checks - all while preserving the formal topology and enforcing idempotence plus mutation protection.
-
-**Key Crates and Modules** (verified):  
-- cutile/src/hit/triweavon_hit.rs and cubical.rs : TriWeavonHIT impl of CubicalHIT trait (append-only)  
-- cutile/src/core/hexaflake.rs entropy.rs srac.rs : recursion, W omega tilde plus viscosity/stretch, cascade plus surge gate (idempotent relaxation)  
-- cutile/src/backend/cuda.rs plus kernels/blackwell_entropy_v2.cu : GPU-accelerated entropy (CPU fallback if no PTX)  
-- Visualization: examples/tqec_braid_viz.rs (egui) plus src/viz/tqec_syndrome.rs
-
-**Cell Model** (0-cell corresponds to point/gen. 1-cell corresponds to glue/d_r/weave/merid. Append-only for mutation protection):
-
-```rust
-// cutile/src/hit/triweavon_hit.rs
-pub struct CubicalCell { dimension: u8, id: u64, ... }
 ```
 
 ---
 
-=====================================
-STORYBOARD FRAME 3 - THE INVARIANT-PRESERVING BRIDGE (Filled Correspondences)
-=====================================
+## 5. Architecture (SAIF layers)
 
-All voided entries from v0.3 have been filled with precise correspondences or explicit future-impl notes. Topology protected: every Agda constructor has a runtime witness that does not alter homotopy type or Serre page index. The mapping is monomorphic (one-to-one canonical image). Operations are idempotent and protected from mutation via append-only semantics and gated updates.
+```
+MCP client (Claude · Cursor · Grok · …)
+        │ stdio / JSON-RPC
+        ▼
+@toolated/coherence-mcp  (TypeScript · this package)
+  WAVE · ATOM · Fibonacci · gates · vortex · connectors
+        │
+        ├── optional SpiralSafe API (ops_*)
+        ├── optional strand APIs (Grok / Gemini / open-weight)
+        └── edge lookup → ws://127.0.0.1:8088 · CF · LogOS surfaces
 
-**Module Index (voids filled, no mutation of original formal structure)**
-
-- Cubical.HITs.S2 used in TriWeavon.HITs.TriWeavonManifold : Role Base 2-sphere (base, surf) for coarse/fine layers : cutile counterpart CubicalCell dimension 0 via add_point  
-- Cubical.HITs.Susp used in TriWeavon.K22.SerreScarr : north/south/merid. hcomp filler via inS : cutile counterpart tomczakLift pattern to hcomp_edge  
-- Cubical.HITs.Pushout used in TriWeavon.K22.SerrePage : inl/inr/push gluing of filtration cells : cutile counterpart sracPageStep to srac_cascade_step depth index. Future: push_weave(inl_id, inr_id)  
-- Cubical.HITs.S1 used in SerreScarPathInduction (legacy) : Stage filtration paths : FILLED Legacy. Superseded by SerreScarr.d_r differentials plus tomczakLift hcomp paths  
-- Cubical.Foundations.Prelude used in all TriWeavon modules : Path, hcomp, transport, compPath : cutile counterpart CubicalHIT, HComp.fill  
-- (custom HIT) used in TriWeavon.HITs.TriWeavonManifold : TwoScaleSphere, Hexaflake, glue/glueRec : cutile counterpart TriWeavonHIT, hexaflake_nodes  
-- (custom HIT) used in TriWeavon.K22.SerreScarr : SerreScarr, d_r, tomczakLift : cutile counterpart CudaEntropyResult, betti_proxy  
-- (record) used in TriWeavon.Tomczak.Lifting : TomczakLifting, LiftGate, liftOk : cutile counterpart betti_tomczak_lift_check
-
-**Manifold HITs Constructor Mapping (voids filled, idempotent and mutation-protected)**
-
-- S2 point pt S2 : Cubical.HITs.S2.base : 0-cell anchor : TriWeavonHIT.add_point() to u64 id (append-only, idempotent on repeat)  
-- coarse x / fine x : path over S2 : two 0-cells in different layers : two add_point() calls. Layer tag implicit in weave graph  
-- glue x : coarse x equiv fine x : 1-path constructor : oriented 1-cell between layers : weave(coarse_id, fine_id) (idempotent: same pair yields equivalent cell)  
-- mirrored : path reversal on glue : involution on cell graph : FILLED Future mirror_weave(a, b). Reverses 1-cell while preserving homotopy type (involution on edge set, idempotent)  
-- Hexaflake.base : 0-cell at level n : node in recursion tree : hexaflake_nodes(r) coordinate  
-- Hexaflake.recurse k : 7-way branching (Fin 7) : 7 sub-tiles per level : hexaflake_nodes count grows approximately 7 times per radius step  
-- Hexaflake.glueRec : path between base and recurse : gluing 1-cell across scales : weave between parent/child node ids  
-- pathInductionAttractor : transport along path : transport along edge : hcomp_edge(a, b, t) at t in [0,1] (boundary idempotent)  
-- E infinity equals Sigma n Hexaflake n : sequential colimit : limit of all recursion levels : hexaflake_nodes(r) for finite truncation r
-
-**Hexaflake Discretization (void filled)**
-
-- Fin 7 recursion arms : 7-neighbor hex lattice : hexaflake_nodes(radius) returns (q,s) axial coords  
-- scale (1/3) x : placeholder in Agda : FILLED Rust uses integer hex radius. Future: introduce Rational scale or sub-tile refinement to match exact 1/3 contraction (protects self-similarity)  
-- E infinity colimit : hexaflake_nodes(r) for finite r : executable truncates at chosen radius (faithful finite model, idempotent truncation)
-
-**hcomp Face Semantics** (verified invariant-preserving, idempotent at boundaries, protected):
-
-- (i equals i0) to t equals 0 : boundary collapse to Some(a)  
-- (i equals i1) to t equals 1 : boundary collapse to Some(b)  
-- interior t in (0,1) : creates interior weave(a,b) filler
-
-HComp.fill(t) equals linear interpolation. Exact 1-d cubical template. No deformation. Idempotent on repeated boundary calls.
-
-**Serre/K22 and Tomczak (voids filled where applicable, mutation-protected gates)**
-
-SerreScarr HIT corresponds to spectral executables. Differentials raise degree. tomczakLift uses Susp/hcomp to stabilize.
-
-SerrePage corresponds to SRAC cascade:  
-- PageCell.r to filtration_depth  
-- Differential.witness (push) to FILLED Planned weave(inl_id, inr_id) in page step  
-- sracPageStep to srac_cascade_step(current, depth, tau) (smooth relaxation, idempotent in steady state)
-
-Tomczak Lifting Gate (exact match, pure predicate hence idempotent and mutation-safe):  
-
-```rust
-pub fn betti_tomczak_lift_check(betti_proxy: f64, lifting_threshold: f64, tomczak_preserved: bool) -> bool {
-    betti_proxy < lifting_threshold && tomczak_preserved
-}
+Companion (not this npm tarball):
+  LogOS cutile · triweavon-cudarc · Mehler CUDA  (Rust / GPU)
+  lean/K22 MOG · Agda HITs                       (formal)
+  orchestrator/ under coherence-mcp repo         (Rust TUI · 0.1.0)
 ```
 
-FILLED: TomczakLifting.lift remains proof-relevant in Agda. Executable collapses to bool flag (sufficient for runtime gate). Future optional proof-term extraction for higher assurance. Gate is pure, repeatable, protects invariants from mutation.
-
-Entropy / Betti / Surge Pipeline formulas align exactly with formal W[omega tilde], viscosity, stretch, betti_proxy count, surge jump detection. All pure or append-only.
+Formal → executable storyboard and release notes:  
+[docs/RELEASE_v0.4.1.md](docs/RELEASE_v0.4.1.md) · [mcp-101/index.md](mcp-101/index.md)
 
 ---
 
-=====================================
-STORYBOARD FRAME 4 - END-TO-END EXECUTION FLOW AND SRAC EFFICIENCY REPORT
-=====================================
+## 6. Verify integrity
 
-**Verified Sovereign Flow** (no deformation at any step. Mono mapping. Idempotent steps. Protected updates):
-
-1. Discretize manifold to hexaflake_nodes(r) (E infinity truncation faithful, idempotent)  
-2. Build cell graph to add_point plus weave (0/1-cells, glue paths preserved, append-only)  
-3. Run entropy pass (page r) to compute_entropy_diagnostic plus CUDA kernel  
-4. Measure Betti plus surge to betti_proxy plus DefaultSurgeDetector  
-5. Tomczak gate to betti_tomczak_lift_check (protects liftOk invariant, pure)  
-6. SRAC correction (if needed) to srac_correct_if_needed(surge, not lift_ok, depth) to srac_cascade_step
-
-**SRAC Propagation Efficiency Report** (passive observer analysis, idempotent and protected):
-
-- srac_cascade_step formula: current plus (phi plus 1 minus current) times (1 minus exp(-tau times depth)). Smooth, monotonic, topology-preserving relaxation. Converges idempotently.  
-- Correction burst triggers only on (surge_detected and not betti_lift_ok), then suggests depth minus 1 to restore invariants.  
-- Observed in tests: finite mesh, no Betti number jumps, Serre page index advances cleanly, tomczak_preserved flag remains true post-correction.  
-- Music conservation: entropy terms (viscosity plus stretch) plus spectral differentials remain coherent. No anomalous resonance or decoherence detected at scale.  
-- Mutation protection: every correction produces new cells or depth adjustment only. Existing graph never mutated in place.
-
-**Reference Pipeline** (from integration.rs, verified mono and protected):
-
-```rust
-let betti = betti_proxy(&grad, threshold);
-let lift_ok = betti_tomczak_lift_check(betti as f64, 1.0, true);
-let surge = detector.detect_surge(current_w, prev_w_avg, 0.5);
-let correction = srac_correct_if_needed(surge, !lift_ok, filtration_depth);
+```bash
+npm view @toolated/coherence-mcp version   # expect 0.4.1
+npm audit signatures @toolated/coherence-mcp
+# optional repo script
+./scripts/verify-release.sh 0.4.1
 ```
 
----
+Snyk (optional, local):
 
-=====================================
-STORYBOARD FRAME 5 - CONSENSUS VALIDATION, ANOMALY DETECTION AND TEST MAP
-=====================================
-
-**Test to Proof Obligation Map** (all executable anchors verified. Formal proofs verified where applicable. All steps idempotent or pure where applicable):
-
-- triweavon_hit_weave_points : weave produces 1-cell between 0-cells : executable verified  
-- hcomp_edge_interpolates_weave : hcomp boundary faces : executable verified (idempotent at boundaries)  
-- hexaflake_grows_with_radius : recurse Fin 7 increases cardinality : executable verified  
-- betti_proxy_counts_hot_gradients : liftOk numerical conjunct : executable verified (pure)  
-- entropy_diagnostic_finite : W[omega tilde] finite on finite mesh : executable verified  
-- srac_and_surge_pipeline : srac_correct_if_needed when not liftOk and surge : executable verified (protected correction)  
-- (no executable) : d_r-coherence proof : Agda refl (proof verified, not runtime)  
-- (no executable) : pathInductionAttractor full J-rule : Agda skeleton only
-
-**Anomaly Detection Summary** (topological dynamics, protected view):
-
-No critical anomalies in core manifold (HIT gluing, hcomp fillers, hexaflake colimit, Serre d_r paths, Tomczak gate).  
-Isolated backlog items flagged in Frame 7. If left unaddressed could induce mild deformation at higher filtration depths or finer scales, but current mappings remain mono and mutation-protected.  
-Cross-agent note: Compatible with at toolated coherence-mcp WAVE validator for automated doc to code coherence scoring (structural plus semantic plus Fibonacci-weighted). Supports trigger_correction_burst for SRAC.
-
----
-
-=====================================
-STORYBOARD FRAME 6 - THE USER JOURNEY (Framed for Sovereign Execution, Mono Idempotent Protected)
-=====================================
-
-**Journey Mandate**: From formal specification to verified executable with continuous topology protection, monomorphic mapping, idempotent operations, and mutation protection. Optional coherence-mcp oversight.
-
-**Bordered Step-by-Step Journey** (protected, repeatable steps):
-
-=====================================
-STEP 1 - AUTHOR FORMAL SPEC (Agda)
-=====================================
-- Define HITs in TriWeavonManifold, SerreScarr, SerrePage, TomczakLifting  
-- Prove liftOk, d_r-coherence, pathInductionAttractor (immutable proofs)  
-- Run: pwsh -File scripts/check.ps1  
-- Outcome: Monomorphic spec. Protected invariants.
-
-=====================================
-STEP 2 - RENDER AND DOCUMENT (HTML)
-=====================================
-- Generate browsable docs: pwsh -File scripts/html.ps1  
-- Cross-link to Cubical.HITs references  
-- Outcome: Single source of truth documentation (mono).
-
-=====================================
-STEP 3 - IMPLEMENT EXECUTABLE BRIDGE (cutile)
-=====================================
-- Extend TriWeavonHIT: add_point, weave, hcomp_edge, hexaflake_nodes (append-only)  
-- Wire entropy_diagnostic, srac_cascade_step, betti_tomczak_lift_check (idempotent gates)  
-- (Optional) Implement backlog items: mirror_weave, push_weave (future idempotent)  
-- Outcome: Mutation-protected implementation.
-
-=====================================
-STEP 4 - VERIFY CONSENSUS (Tests plus Audit)
-=====================================
-- cargo test -p cutile  
-- Observer mode: inspect surge, betti_proxy, lift_ok, correction bursts (repeatable, pure checks)  
-- Ingest into coherence-mcp for WAVE scoring of mapping fidelity  
-- Outcome: Verified mono idempotent protected bridge.
-
-=====================================
-STEP 5 - VISUALIZE AND INSPECT TOPOLOGY (tqec braid)
-=====================================
-- cargo run -p cutile --example tqec_braid_viz --features viz  
-- Observe: cyan 0-cells, amber weaves/SRAC braids, purple entropy field  
-- Trigger SRAC correction bursts. Verify no deformation of cell graph (idempotent observation)  
-- Outcome: Visual confirmation of invariant protection.
-
-=====================================
-STEP 6 - SCALE AND GPU ACCELERATE
-=====================================
-- pwsh -File scripts/build_ptx.ps1 (requires nvcc)  
-- cargo build --features cuda  
-- Monitor SRAC efficiency at higher hexaflake radii and filtration depths (protected scaling)  
-- Outcome: Efficient mono execution at scale.
-
-=====================================
-STEP 7 - CONTINUOUS VERIFICATION (Long-term Health)
-=====================================
-- Integrate at toolated coherence-mcp trigger_correction_burst  
-- Periodic WAVE audit of docs versus code  
-- On-demand active correction when anomalies (gaps) or surge detected (idempotent bursts)  
-- Outcome: Sovereign long-term health. Topology protected from mutation.
-
-**Journey Outcome**: Sovereign execution achieved. Topology invariants protected. Music conserved. Mapping is monomorphic and operations idempotent. Ready for team oversight assignment. All steps repeatable without side-effect accumulation.
-
----
-
-=====================================
-STORYBOARD FRAME 7 - KNOWN GAPS AND STRATEGIC CORRECTION ROADMAP
-=====================================
-
-Gaps remain isolated. Correction bursts recommended for long-term health. All proposed fixes preserve mono mapping, idempotence, and mutation protection.
-
-- mirrored involution : TriWeavonManifold.mirrored : no mirror_weave : medium priority : Add mirror_weave reversing 1-cell. Preserves orientation-reversing paths and homotopy. Idempotent involution.  
-- Pushout.push : SerrePage.Differential : no pushout weave : high priority : Implement push_weave(inl_id, inr_id) in sracPageStep. Protects exact gluing of filtration cells. Mutation-safe append.  
-- PageCell.p bidegree : bidegree field : not in CudaEntropyResult : low priority : Extend entropy result struct or page state. Minor for current filtration_depth focus.  
-- TomczakLifting.lift : proof-relevant : only bool preserved flag : medium priority : Keep bool gate. Add optional proof-term stub for higher-assurance builds. Pure predicate.  
-- scale (1/3) : rational scaling : integer hex radius only : low priority : Introduce Rational or fixed-point refinement in hexaflake. Protects exact self-similarity of E infinity.  
-- GPU path : none : PTX not built (used_gpu_kernel false) : high priority : Build PTX. Enables full-scale SRAC without CPU fallback. Protected acceleration.
-
-**Strategic Note**: Addressing high-priority items (push_weave, GPU) via on-demand correction bursts will raise consensus fidelity to greater than 98 percent and eliminate any residual risk of filtration or scale deformation while maintaining mono idempotent protected properties.
-
----
-
-=====================================
-APPENDIX - VERSION LOCK, BUILD COMMANDS, CROSS-LINKS
-=====================================
-
-**Version Lock**:  
-- cutile crate: 0.3.0  
-- Agda bridge tag: TriWeavon.Core.cutileVersion equals 0.3.0  
-- agda/cubical: pinned vendor  
-- This paradigm: v0.4 (sovereign consensus edition, mono idempotent protected)
-
-**Build Commands** (unchanged, verified repeatable):  
-
-```powershell
-# Agda
-cd F:\Users\Matthew Ruhnau\LogOS\agda
-pwsh -File scripts/vendor.ps1
-pwsh -File scripts/check.ps1
-pwsh -File scripts/html.ps1
-
-# cutile
-cd F:\Users\Matthew Ruhnau\LogOS\cutiles\cutile
-cargo test -p cutile
-pwsh -File scripts/build_ptx.ps1
-cargo build -p cutile --features cuda
+```bash
+# retries / timeout if CI is flaky
+export SNYK_MAX_ATTEMPTS=3
+export SNYK_TIMEOUT_SECS=300
+snyk test --file=package.json
 ```
 
-**Related**:  
-- Visualization: tqec-visualization.md  
-- Coherence MCP: https://www.npmjs.com/package/@toolated/coherence-mcp (WAVE plus SRAC plus TriWeavon strands, supports trigger_correction_burst)  
-- Rendered Cubical: https://agda.github.io/cubical/Cubical.HITs.html
+Proxy: standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` for both npm and Snyk.
 
 ---
 
-**Final Sovereign Declaration**  
-This v0.4 paradigm fills all previously voided entries, frames the complete user journey as a protected repeatable storyboard, and deploys horizontal-bordered sections only (no vertical lines). The Tri-Weavon manifold topology remains invariant under the formal to executable functor. The bridge is monomorphic. Operations are idempotent. Updates are protected from mutation. SRAC propagates efficiently. Music is conserved.  
+## 7. Security posture
 
-Ready for continuous verification and kparrish51-tagged toolchain ingestion. All properties preserved under regeneration.
+- **SafeSkill** scan on npm may flag ~65/100 — treat as caution, not a pass/fail ship gate.  
+- Prefer least-privilege tokens; never commit `.env`.  
+- `ops_deploy` and production connectors are **guarded** — dry-run first.  
+- Conservation: any handoff that violates α + ω = 15 must **SlowStep**, not force-push.
 
-- Monitoring and Consensus Verifier (passive observer, on-demand correction ready, mono idempotent protected)
+---
+
+## 8. Links
+
+- npm: https://www.npmjs.com/package/@toolated/coherence-mcp  
+- Source: https://github.com/toolate28/coherence-mcp  
+- Homepage: https://spiralsafe.org  
+- Site: https://coherence.toolated.online  
+- LogOS: https://github.com/toolate28/LogOS  
+
+---
+
+## 9. Related SAIF docs (LogOS)
+
+- `SAIF-Docs/UNITARY-RELEASE-v1.0.md` — deploy waist / sensors  
+- `SAIF-Docs/Mehler_CoherenceMCP_Wiring_v0.5.0.md` — Mehler certified path  
+- `SAIF-Docs/COHERENCE-MCP-STACK-STATUS-20260717.md` — dual TS/Rust status  
+
+✦ Unitary · SAIF · α+ω=15 · WAVE ≥ 0.85 for publish paths

--- a/docs/CAPABILITY-MAP-v0.4.1.md
+++ b/docs/CAPABILITY-MAP-v0.4.1.md
@@ -1,0 +1,349 @@
+# Capability Map · @toolated/coherence-mcp v0.4.1
+
+**Audience:** Claude (or any strand) cross-check + smoke test  
+**Package:** `@toolated/coherence-mcp@0.4.1`  
+**Invariant:** α + ω = 15  
+**ATOM:** post-npm ship · 2026-07-16  
+**SAIF:** KENL → AWI → ATOM → SAIF → Safe Spiral  
+
+This is the **full capability specification** for the published TypeScript MCP server.  
+Companion formal/GPU surfaces (cutile, Mehler, MOG Lean) are **out of band** of this npm tarball unless noted.
+
+---
+
+## 0. One sentence
+
+Fifty-eight MCP tools form Tier-0 SAIF bedrock: measure coherence (WAVE), prove conservation (invariant), trail decisions (ATOM), weight criticality (Fibonacci), translate strands (vortex), and hang connectors — so fault-tolerant multi-agent topology can gate before any quantum/topological execution layer runs.
+
+---
+
+## 1. Identity board
+
+```crease
+  ◆ PACKAGE IDENTITY ◇
+╭──────────────────┬────────────────────────────────────╮
+│ Field            │ Value                              │
+├──────────────────┼────────────────────────────────────┤
+│ npm name         │ @toolated/coherence-mcp            │
+│ version          │ 0.4.1                              │
+│ transport        │ stdio MCP (JSON-RPC)               │
+│ runtime          │ Node ≥ 18                          │
+│ bin              │ coherence-mcp · coherence-mcp-setup│
+│ tool count       │ 58                                 │
+│ license          │ MIT                                │
+│ repo             │ toolate28/coherence-mcp            │
+│ server.name code │ "coherence-mcp" (may lag package)  │
+│ server.version   │ "0.3.2" in index.ts (KNOWN DRIFT)  │
+╰──────────────────┴────────────────────────────────────╯
+  α+ω=15 · crease=miura
+```
+
+**Known drift for Claude to flag:** `Server({ version: "0.3.2" })` in `src/index.ts` does not match package `0.4.1`. Smoke test should record this; fix is a patch commit.
+
+---
+
+## 2. SAIF gate → tool mapping
+
+```crease
+  ◆ SAIF × TOOLS ◇
+╭────────────┬──────────────────────────────────────────╮
+│ Gate       │ Primary tools                            │
+├────────────┼──────────────────────────────────────────┤
+│ KENL       │ docs_search · manifest_read · gem_init   │
+│ AWI        │ vortex_platforms · integrate · network_  │
+│            │ state · strand list_*                    │
+│ ATOM       │ atom_track · context_pack · bump_validate│
+│            │ handoff_packet_validate                  │
+│ SAIF       │ invariant_check · wave_validate ·        │
+│            │ wave_coherence_check · wave_analyze      │
+│            │ gate_intention_to_execution ·            │
+│            │ gate_execution_to_learning               │
+│ Safe Spiral│ ops_health · trigger_correction_burst ·  │
+│            │ dropout_scan · cleanroom_scour ·         │
+│            │ edge_endpoint_lookup                     │
+╰────────────┴──────────────────────────────────────────╯
+  α+ω=15 · crease=waterbomb
+```
+
+SPHINX-style verbal gates (if using coherence-mcp gate_transition naming elsewhere):
+
+- knowledge → intention: KENL band  
+- intention → execution: `gate_intention_to_execution`  
+- execution → learning: `gate_execution_to_learning`  
+- learning → regeneration: `trigger_correction_burst` + WAVE re-check  
+
+---
+
+## 3. Full tool catalog (58)
+
+### 3.1 WAVE (3)
+
+| Tool | Role | Required args | Env |
+|------|------|---------------|-----|
+| `wave_coherence_check` | Doc vs code WAVE alignment | `documentation`, `code` | — |
+| `wave_analyze` | Curl / divergence / potential on text | `input` | — |
+| `wave_validate` | Full WAVE 0–100 + threshold | `content` | — |
+
+**Thresholds:** 60 baseline · 80 emergent · 85 publish/handoff · 99 critical.
+
+### 3.2 GATE / conservation (3)
+
+| Tool | Role | Required args | Env |
+|------|------|---------------|-----|
+| `invariant_check` | α + ω = 15 load-bearing gate | (none or gauge fields) | — |
+| `bump_validate` | H&&S handoff markers | `handoff` | — |
+| `handoff_packet_validate` | HANDOFF_PACKET schema | packet fields | — |
+
+### 3.3 ATOM / context (3)
+
+| Tool | Role | Required args | Env |
+|------|------|---------------|-----|
+| `atom_track` | Decision trail | `decision` (+ files/tags) | optional ATOM token |
+| `context_pack` | `.context.yaml` pack + hash | `docPaths`, `meta` | paths on disk |
+| `manifest_read` | LogOS manifests JSON | path/name | LogOS tree |
+
+### 3.4 SAIF phase gates (2)
+
+| Tool | Role | Required args | Env |
+|------|------|---------------|-----|
+| `gate_intention_to_execution` | AWI → ATOM | gate context | — |
+| `gate_execution_to_learning` | ATOM → SAIF | gate context | — |
+
+### 3.5 Fibonacci (5)
+
+| Tool | Role |
+|------|------|
+| `fibonacci_assign_weight` | Weight component by importance |
+| `fibonacci_calculate_impact` | Failure impact = weight × degradation |
+| `fibonacci_optimize_allocation` | Budget allocation by Fib weights |
+| `fibonacci_find_critical_paths` | Critical path / risk groups |
+| `fibonacci_refine_threshold` | Threshold × φ |
+
+### 3.6 Vortex bridge (3)
+
+| Tool | Role |
+|------|------|
+| `vortex_translate` | Cross-platform semantic translate |
+| `vortex_verify` | Source vs translation coherence |
+| `vortex_platforms` | Platform capability list |
+
+### 3.7 Strand adapters (10)
+
+| Tool | Role | Env |
+|------|------|-----|
+| `grok_generate` | xAI chat | `XAI_API_KEY` |
+| `grok_check_coherence` | Grok WAVE-ish score | `XAI_API_KEY` |
+| `grok_list_models` | List xAI models | `XAI_API_KEY` |
+| `grok_translate` | Translate for Grok | optional |
+| `gemini_translate` | Gemini translate | Google key |
+| `gemini_check_coherence` | Gemini score | Google key |
+| `openweight_generate` | Local LLM complete | open-weight endpoint |
+| `openweight_check_coherence` | Local score | endpoint |
+| `openweight_list_models` | List local models | endpoint |
+| `gem_init` | Polymorphic rendering seed | — |
+
+### 3.8 Ops / SpiralSafe API (3)
+
+| Tool | Role | Env |
+|------|------|-----|
+| `ops_health` | API health | `SPIRALSAFE_API_TOKEN` |
+| `ops_status` | API status | token |
+| `ops_deploy` | Deploy (guarded) | token · **dry-run first** |
+
+### 3.9 Bedrock / LogOS (7)
+
+| Tool | Role |
+|------|------|
+| `docs_search` | SpiralSafe corpus search |
+| `dropout_scan` | Dropout registry gaps |
+| `rust_workspace_status` | LogOS crate health |
+| `network_state` | Coherence network state |
+| `integrate` | Integrate entity into network |
+| `cleanroom_scour` | Extract protected cores |
+| `anamnesis_validate` | Exploit/AI code validation gates |
+
+### 3.10 Industry connectors (9)
+
+| Tool | Env |
+|------|-----|
+| `github_file` | `GITHUB_TOKEN` |
+| `github_status` | `GITHUB_TOKEN` |
+| `github_issue` | `GITHUB_TOKEN` |
+| `jira_create` | `JIRA_URL`, `JIRA_EMAIL`, `JIRA_TOKEN` |
+| `jira_search` | same |
+| `slack_notify` | webhook URL |
+| `postgres_query` | `POSTGRES_URL` |
+| `postgres_store` | `POSTGRES_URL` |
+| `fetch_url` | network |
+
+### 3.11 Client scaffolds (4)
+
+| Tool | Role |
+|------|------|
+| `android_bridge` | ADB MCP bridge |
+| `android_scaffold` | Kotlin client scaffold |
+| `windows_bridge` | PowerShell MCP invoke |
+| `windows_scaffold` | .NET client scaffold |
+
+### 3.12 Minecraft / HOPE (4)
+
+| Tool | Role | Env |
+|------|------|-----|
+| `mc_exec` | RCON command | MC RCON creds |
+| `mc_query` | Server status | — |
+| `mc_npc` | hope-ai-npc pipeline | suite config |
+| `mc_conservation_verify` | α+ω=15 in MC domain | — |
+
+### 3.13 Edge / SRAC (2)
+
+| Tool | Role |
+|------|------|
+| `edge_endpoint_lookup` | Bridge :8088 · CF · TriWeavon endpoints |
+| `trigger_correction_burst` | SRAC correction on coherence field |
+
+---
+
+## 4. Out-of-band (not in 0.4.1 tarball tools list)
+
+These appear in LogOS `mcps/coherence-mcp/tools/` or SAIF docs but are **not** in the 58-name `TOOLS` array of published `src/index.ts`:
+
+- `mehler_plateau_monitor` — Mehler wiring v0.5.0 (cutile/Rust path)  
+- `store_context` / `retrieve_context` / `map_isomorphism` / `check_coherence` / `bridge_translate` — alternate naming / older bedrock aliases  
+- `x_post` / `x_search` / … — X social (may live on other branches)  
+- `rust_toolchain_status` — sibling of workspace status  
+
+Claude cross-check: **list tools via MCP** and diff against §3; report any extra/missing.
+
+---
+
+## 5. Environment matrix
+
+| Variable | Required for | Band |
+|----------|--------------|------|
+| `ATOM_AUTH_TOKEN` | authenticated atom ops | ATOM |
+| `SPIRALSAFE_API_TOKEN` | ops_* | OPS |
+| `WAVE_TOOLKIT_BIN` | optional external WAVE CLI | WAVE |
+| `XAI_API_KEY` | grok_* | STRAND |
+| `GITHUB_TOKEN` | github_* | CONNECTOR |
+| `JIRA_*` | jira_* | CONNECTOR |
+| `POSTGRES_URL` | postgres_* | CONNECTOR |
+| Open-weight base URL | openweight_* | STRAND |
+| Google Gemini key | gemini_* | STRAND |
+
+Snyk (optional CI; not an MCP tool):
+
+- `SNYK_MAX_ATTEMPTS` · `SNYK_TIMEOUT_SECS` · `SNYK_CACHE_PATH`  
+- `SNYK_CFG_ORG` · proxy `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`  
+
+---
+
+## 6. Claude smoke-test protocol
+
+**Goal:** prove install + bedrock without burning paid APIs.
+
+### 6.1 Preflight (host)
+
+```bash
+npm view @toolated/coherence-mcp version   # 0.4.1
+node -v                                    # >= 18
+npx -y @toolated/coherence-mcp@0.4.1 --help  # or start under MCP client
+```
+
+### 6.2 Phase A — offline / no API keys (must pass)
+
+Run via MCP client tool calls:
+
+1. **`invariant_check`** — expect pass when α+ω=15 (or clear fail message).  
+2. **`wave_validate`** — content: short markdown + claim of conservation; threshold 60.  
+3. **`wave_analyze`** — same content; expect curl/divergence/potential fields or structured analysis.  
+4. **`wave_coherence_check`** — trivial doc/code pair that match.  
+5. **`vortex_platforms`** — list non-empty.  
+6. **`bump_validate`** — minimal handoff object with source/target/payload; record accept/reject.  
+7. **`fibonacci_assign_weight`** — name + importance mid-range.  
+8. **`edge_endpoint_lookup`** — resolve default bridge host (may report down; must not crash).  
+
+**Pass criteria:** no uncaught server crash; JSON responses; invariant tool is callable.
+
+### 6.3 Phase B — optional keys
+
+| If set | Call | Expect |
+|--------|------|--------|
+| `XAI_API_KEY` | `grok_list_models` | model list |
+| `GITHUB_TOKEN` | `github_status` dry read or `github_file` public file | content |
+| `SPIRALSAFE_API_TOKEN` | `ops_health` | health JSON |
+| LogOS checkout | `rust_workspace_status` · `manifest_read` | filesystem truth |
+
+### 6.4 Phase C — do not run in smoke (unless intentional)
+
+- `ops_deploy` (production side effects)  
+- `mc_exec` against live survival servers  
+- `postgres_store` without test DB  
+- `trigger_correction_burst` at high intensity on shared field  
+
+### 6.5 Phase D — SAIF narrative smoke
+
+1. KENL: `docs_search` or `manifest_read`  
+2. AWI: `vortex_platforms`  
+3. ATOM: `atom_track` with decision string `SMOKE-0.4.1`  
+4. SAIF: `invariant_check` + `wave_validate` threshold 85  
+5. Safe Spiral: `ops_health` or `dropout_scan`  
+
+Record WAVE score and invariant result in a one-line ATOM note.
+
+### 6.6 Claude report template
+
+```
+CAPABILITY SMOKE · @toolated/coherence-mcp@0.4.1
+date:
+client:
+tools_listed_count:   # from MCP list_tools
+tools_expected: 58
+diff_missing:
+diff_extra:
+server_reported_version:
+phase_A: PASS|FAIL  (notes)
+phase_B: SKIP|PASS|FAIL
+phase_D_SAIF: PASS|FAIL
+invariant: PASS|FAIL
+wave_sample_score:
+known_drift: server.version 0.3.2 vs package 0.4.1
+recommendation: ship_ok | patch_version_string | block
+```
+
+---
+
+## 7. FTQTC relevance (why this map exists)
+
+Fault-tolerant **quantum topological** computation needs classical **control-plane coherence** before anyonic/code layers move:
+
+1. **Conservation gate** (`invariant_check`, `mc_conservation_verify`) — same α+ω=15 as LogOS.  
+2. **Syndrome-like scoring** (WAVE) — classical stand-in for “is the description of the code matching the implementation.”  
+3. **SRAC** (`trigger_correction_burst`) — classical correction burst before GPU Mehler / cutile.  
+4. **Strand vortex** — multi-agent handoff without destroying semantics (topological “braid” of intent).  
+5. **Handoff packets** — nested SlowStep instead of hard prune when gates fail.
+
+This package does **not** implement TQEC decoders; it **gates** the agents and docs that drive cutile / MOG / Mehler.
+
+---
+
+## 8. Cross-check checklist (Claude)
+
+- [ ] `npm list -g @toolated/coherence-mcp` or local install shows **0.4.1**  
+- [ ] MCP `list_tools` count ≈ **58**  
+- [ ] No tool uses wrong package id `@toolete28/...` in docs  
+- [ ] README SAIF path present on GitHub after push  
+- [ ] Phase A smoke green  
+- [ ] File `server.version` drift issue  
+- [ ] Diff LogOS `mcps/coherence-mcp/tools/*.json` vs §3 (alias backlog)  
+
+---
+
+## 9. Related files
+
+- [README.md](../README.md) — SAIF ship surface  
+- [mcp-101/index.md](../mcp-101/index.md) — get-started  
+- [RELEASE_v0.4.1.md](RELEASE_v0.4.1.md) — release narrative  
+- LogOS: `SAIF-Docs/Mehler_CoherenceMCP_Wiring_v0.5.0.md`  
+- LogOS: `docs/sovereign-handoff/session-handovers/HO-06-SUPERGROKOS-V3.md`  
+
+✦ α + ω = 15 · WAVE ≥ 0.85 handoff · SlowStep over prune · The Keystone Holds

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ import {
 const server = new Server(
   {
     name: "coherence-mcp",
-    version: "0.3.2",
+    version: "0.4.1",
   },
   {
     capabilities: {


### PR DESCRIPTION
## Summary
- SAIF-reworked README (KENL→AWI→ATOM→SAIF→Safe Spiral, crease boards, correct npm id)
- Full capability map: all 58 tools, env matrix, Claude smoke protocol (Phase A–D)
- Align MCP Server version string to 0.4.1 (was 0.3.2 drift)

## Test plan
- [ ] Claude: list_tools count ≈ 58 vs CAPABILITY-MAP §3
- [ ] Phase A smoke (invariant_check, wave_*, vortex_platforms)
- [ ] npm page still 0.4.1; README on GitHub updates after merge (npm tarball README updates on 0.4.2 if republished)

npm already published 0.4.1; this is docs + version string alignment for main.